### PR TITLE
Correct Alegro shift convention

### DIFF
--- a/gridcapa-core-valid-app/src/main/java/com/farao_community/farao/gridcapa_core_valid/app/services/NetPositionsHandler.java
+++ b/gridcapa-core-valid-app/src/main/java/com/farao_community/farao/gridcapa_core_valid/app/services/NetPositionsHandler.java
@@ -54,11 +54,11 @@ public final class NetPositionsHandler {
                 if (studyPointZoneId.equals("NP_BE_ALEGrO")) {
                     // XLI_OB1B
                     Optional<DanglingLine> danglingLine = network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1B")).findAny();
-                    danglingLine.ifPresent(dl -> dl.setP0(netPosition));
+                    danglingLine.ifPresent(dl -> dl.setP0(-netPosition));
                 } else if (studyPointZoneId.equals("NP_DE_ALEGrO")) {
                     // XLI_OB1A
                     Optional<DanglingLine> danglingLine = network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1A")).findAny();
-                    danglingLine.ifPresent(dl -> dl.setP0(netPosition));
+                    danglingLine.ifPresent(dl -> dl.setP0(-netPosition));
                 } else {
                     String zone = CoreAreasId.ID_MAPPING.get(studyPointZoneId);
                     double shift = netPosition - coreNetPositions.getOrDefault(zone, 0.);

--- a/gridcapa-core-valid-app/src/test/java/com/farao_community/farao/gridcapa_core_valid/app/services/NetPositionsHandlerTest.java
+++ b/gridcapa-core-valid-app/src/test/java/com/farao_community/farao/gridcapa_core_valid/app/services/NetPositionsHandlerTest.java
@@ -77,8 +77,8 @@ class NetPositionsHandlerTest {
         assertEquals(716.25, network.getGenerator("NNL1AA1 _generator").getTargetP(), 0.01);
         assertEquals(-1328.75, network.getGenerator("NNL2AA1 _generator").getTargetP(), 0.01);
         assertEquals(-612.5, network.getGenerator("NNL3AA1 _generator").getTargetP(), 0.01);
-        assertEquals(-600.0, network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1B")).findAny().get().getP0(), 0.01);
-        assertEquals(600.0, network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1A")).findAny().get().getP0(), 0.01);
+        assertEquals(600.0, network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1B")).findAny().get().getP0(), 0.01);
+        assertEquals(-600.0, network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1A")).findAny().get().getP0(), 0.01);
     }
 
     @Test
@@ -129,7 +129,7 @@ class NetPositionsHandlerTest {
         assertEquals(1425.0, network.getGenerator("NNL1AA1 _generator").getTargetP(), 0.01);
         assertEquals(325.0, network.getGenerator("NNL2AA1 _generator").getTargetP(), 0.01);
         assertEquals(1750.0, network.getGenerator("NNL3AA1 _generator").getTargetP(), 0.01);
-        assertEquals(234.0, network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1B")).findAny().get().getP0(), 0.01);
-        assertEquals(-234.0, network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1A")).findAny().get().getP0(), 0.01);
+        assertEquals(-234.0, network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1B")).findAny().get().getP0(), 0.01);
+        assertEquals(234.0, network.getDanglingLineStream().filter(dl -> dl.getUcteXnodeCode().equals("XLI_OB1A")).findAny().get().getP0(), 0.01);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
When shifting the network on Alegro, the NetPositionsHandler sets the dangling lines' (equivalent model of Alegro) P0 to the value of the net position. However, in the PowSyBl convention, a DanglingLine acts like a load. 
Thus the value of P0 should be the opposite of the net position (which is given in a generator convention), otherwise shift & LF computations are wrong.

**What is the new behavior (if this is a feature change)?**
P0 is now set to the opposite of the NP value.
